### PR TITLE
feat: Add Targets column to move selection table

### DIFF
--- a/src/app/features/pokemon-build/tables/filterable-table/filterable-table.component.html
+++ b/src/app/features/pokemon-build/tables/filterable-table/filterable-table.component.html
@@ -95,6 +95,9 @@
                           }
                           <div class="column-value" [ngClass]="{ 'column-value-left': column.alignLeft }">
                             {{ column.displayFn ? column.displayFn(entry.data) : entry.data[column.field] }}
+                            @if (column.tooltipFn && column.tooltipFn(entry.data)) {
+                              <mat-icon class="cell-warning-icon" [matTooltip]="column.tooltipFn(entry.data)!" matTooltipPosition="above" [matTooltipShowDelay]="300">warning</mat-icon>
+                            }
                           </div>
                         </div>
                       }

--- a/src/app/features/pokemon-build/tables/filterable-table/filterable-table.component.scss
+++ b/src/app/features/pokemon-build/tables/filterable-table/filterable-table.component.scss
@@ -291,6 +291,16 @@ app-pokemon-sprite.image-icon {
   line-height: 1;
 }
 
+.cell-warning-icon {
+  font-size: 1.1em;
+  width: 1.1em;
+  height: 1.1em;
+  vertical-align: middle;
+  margin-left: 0.25em;
+  color: #e0a800;
+  cursor: default;
+}
+
 .column-value-left {
   text-align: left;
   width: 100%;

--- a/src/app/features/pokemon-build/tables/filterable-table/filtered-table-types.ts
+++ b/src/app/features/pokemon-build/tables/filterable-table/filtered-table-types.ts
@@ -28,6 +28,7 @@ export class ColumnConfig<T> {
   sortable = false
   filterable = false
   displayFn?: (item: T) => string | number | boolean | any
+  tooltipFn?: (item: T) => string
   isImageColumn = false
   isPokemonImageColumn = false
   isPokemonType = false

--- a/src/app/features/pokemon-build/tables/moves-table/moves-table.component.html
+++ b/src/app/features/pokemon-build/tables/moves-table/moves-table.component.html
@@ -2,7 +2,7 @@
   [data]="movesData()"
   [haveFocus]="haveFocus()"
   [selectedValues]="actualMoves()"
-  [columns]="moveColumns"
+  [columns]="moveColumns()"
   [dataFilter]="dataFilter()"
   [initialValue]="initialValue()"
   [isMobile]="isMobile()"

--- a/src/app/features/pokemon-build/tables/moves-table/moves-table.component.ts
+++ b/src/app/features/pokemon-build/tables/moves-table/moves-table.component.ts
@@ -75,43 +75,74 @@ export class MovesTableComponent {
     return details
   }
 
-  moveColumns: ColumnConfig<MoveDetail>[] = [
-    new ColumnConfig<MoveDetail>({ field: "name", header: "Name", sortable: true, alignLeft: true, width: "medium", freezeOnMobile: true }),
-    new ColumnConfig<MoveDetail>({
-      field: "category",
-      header: "Cat",
-      description: "Move category",
-      filterable: true,
-      isImageColumn: true,
-      displayFn: (item: MoveDetail) => `assets/icons/${item.category.toLowerCase()}.png`,
-      filterValues: ["Physical", "Special", "Status"],
-      width: "small"
-    }),
-    new ColumnConfig<MoveDetail>({
-      field: "basePower",
-      header: "BP",
-      description: "Base Power",
-      sortable: true,
-      showHeaderInCell: true,
-      width: "small"
-    }),
-    new ColumnConfig<MoveDetail>({
-      field: "accuracy",
-      header: "Acc",
-      description: "Accuracy",
-      sortable: true,
-      displayFn: (item: MoveDetail) => (typeof item.accuracy === "number" ? `${item.accuracy}%` : "-"),
-      showHeaderInCell: true,
-      width: "verysmall"
-    }),
-    new ColumnConfig<MoveDetail>({
-      field: "pp",
-      header: "PP",
-      description: "PP",
-      sortable: true,
-      showHeaderInCell: true,
-      width: "small"
-    }),
-    new ColumnConfig<MoveDetail>({ field: "description", header: "Description", description: "Description", alignLeft: true })
-  ]
+  moveColumns = computed<ColumnConfig<MoveDetail>[]>(() => {
+    const columns: ColumnConfig<MoveDetail>[] = [
+      new ColumnConfig<MoveDetail>({ field: "name", header: "Name", sortable: true, alignLeft: true, width: "medium", freezeOnMobile: true }),
+      new ColumnConfig<MoveDetail>({
+        field: "category",
+        header: "Cat",
+        description: "Move category",
+        filterable: true,
+        isImageColumn: true,
+        displayFn: (item: MoveDetail) => `assets/icons/${item.category.toLowerCase()}.png`,
+        filterValues: ["Physical", "Special", "Status"],
+        width: "small"
+      }),
+      new ColumnConfig<MoveDetail>({
+        field: "basePower",
+        header: "BP",
+        description: "Base Power",
+        sortable: true,
+        showHeaderInCell: true,
+        width: "small"
+      }),
+      new ColumnConfig<MoveDetail>({
+        field: "accuracy",
+        header: "Acc",
+        description: "Accuracy",
+        sortable: true,
+        displayFn: (item: MoveDetail) => (typeof item.accuracy === "number" ? `${item.accuracy}%` : "-"),
+        showHeaderInCell: true,
+        width: "verysmall"
+      }),
+      new ColumnConfig<MoveDetail>({
+        field: "pp",
+        header: "PP",
+        description: "PP",
+        sortable: true,
+        showHeaderInCell: true,
+        width: "small"
+      })
+    ]
+
+    if (this.store.game() === "champions") {
+      columns.push(
+        new ColumnConfig<MoveDetail>({
+          field: "target",
+          header: "Targets",
+          description: "Opponents hit",
+          displayFn: (item: MoveDetail) => this.targetsHit(item),
+          tooltipFn: (item: MoveDetail) => (item.target === "allAdjacent" ? "Also hits your ally" : ""),
+          showHeaderInCell: true,
+          width: "small"
+        })
+      )
+    }
+
+    columns.push(new ColumnConfig<MoveDetail>({ field: "description", header: "Description", description: "Description", alignLeft: true }))
+
+    return columns
+  })
+
+  private targetsHit(move: MoveDetail): string {
+    if (move.target === "allAdjacentFoes" || move.target === "allAdjacent") {
+      return "2"
+    }
+
+    if (move.target === "self" || move.target === "adjacentAlly" || move.target === "adjacentAllyOrSelf" || move.target === "allySide" || move.target === "allyTeam" || move.target === "allies" || move.target === "foeSide" || move.target === "all") {
+      return "-"
+    }
+
+    return "1"
+  }
 }


### PR DESCRIPTION
## What

Adds a **Targets** column to the move selection table (Champions mode) so players can tell how many opponents a move hits.

| Value | Meaning | Examples |
|-------|---------|----------|
| `2`   | Spread move that hits both opponents (`allAdjacentFoes` / `allAdjacent`) | Heat Wave, Earthquake |
| `1`   | Single-target damaging move | Flamethrower, Solar Beam |
| `-`   | Does not hit opponents (self / ally / field / weather) | Protect, Sunny Day |

Moves that also hit your ally (`allAdjacent`, e.g. Surf / Earthquake) show a small warning icon next to the `2` with a tooltip **"Also hits your ally"** to highlight the friendly-fire risk. Moves that hit only the foes (`allAdjacentFoes`, e.g. Heat Wave) show `2` with no icon.

The column is only rendered in **Champions** mode.

## How

- `MoveDetail.target` already carries the targeting info, so no data changes were needed.
- The column is config-driven: a new `ColumnConfig` is conditionally added to `moves-table.component.ts` when the game is `champions`, with a `targetsHit()` helper mapping the target to `2` / `1` / `-`.
- Added a generic, reusable `tooltipFn` option to `ColumnConfig`; when present, `filterable-table` renders a warning icon with a tooltip beside the cell value. The Targets column uses it to flag `allAdjacent` moves.

## Validation

Verified in the browser (Champions mode):

- Heat Wave (`allAdjacentFoes`) → `2`, no icon
- Earthquake (`allAdjacent`) → `2` + warning icon, tooltip "Also hits your ally"
- Solar Beam / Rock Tomb (single) → `1`
- Protect / Sunny Day / Roost (self/field) → `-`
- SV (non-Champions) mode → column not shown

Closes #14