### PR TITLE
feat: Allies Fainted as clickable buttons for Last Respects / Supreme Overlord

### DIFF
--- a/cypress/e2e/damage-calculation-with-mechanic.cy.ts
+++ b/cypress/e2e/damage-calculation-with-mechanic.cy.ts
@@ -161,30 +161,6 @@ describe("Test calcs from moves with some mechanic", () => {
 
       leftDamageResult.damageIs(0, 132.3, 156.5, 274, 324)
     })
-
-    it("with 4 allie fainted", () => {
-      leftPokemonBuild.allieFainted(4)
-
-      leftDamageResult.damageIs(0, 165.2, 194.6, 342, 403)
-    })
-
-    it("with 5 allie fainted", () => {
-      leftPokemonBuild.allieFainted(5)
-
-      leftDamageResult.damageIs(0, 198.5, 233.8, 411, 484)
-    })
-
-    it("with 6 allie fainted", () => {
-      leftPokemonBuild.allieFainted(6)
-
-      leftDamageResult.damageIs(0, 230.9, 272.4, 478, 564)
-    })
-
-    it("with 7 allie fainted", () => {
-      leftPokemonBuild.allieFainted(7)
-
-      leftDamageResult.damageIs(0, 264.2, 311.5, 547, 645)
-    })
   })
 
   describe("Rage Fist", () => {

--- a/cypress/page-object/pokemon-build.ts
+++ b/cypress/page-object/pokemon-build.ts
@@ -317,7 +317,7 @@ export class PokemonBuild {
   }
 
   allieFainted(alliesFainted: number) {
-    this.container().find(`[data-cy="allies-fainted"]`).click().get("mat-option").contains(alliesFainted.toString()).click()
+    this.container().find(`[data-cy="allies-fainted-${alliesFainted}"]`).click()
   }
 
   hitsTaken(hitsTaken: number) {

--- a/src/app/features/pokemon-build/multi-hit-combo-box/multi-hit-combo-box.component.html
+++ b/src/app/features/pokemon-build/multi-hit-combo-box/multi-hit-combo-box.component.html
@@ -1,13 +1,14 @@
 @if (pokemon().activeMoveName === "Last Respects" || pokemon().ability.name === "Supreme Overlord") {
-  <app-input-autocomplete
-    label="Allies Fainted"
-    [leftLabel]="leftLabel()"
-    [value]="pokemon().moveSet.activeMove.alliesFainted"
-    [allValues]="alliesFainted()"
-    [haveFocus]="haveFocus()"
-    (selected)="selected.emit()"
-    (valueChange)="alliesFaintedChanged($event)"
-    data-cy="allies-fainted" />
+  <div class="allies-fainted" [ngClass]="{ 'allies-fainted-row': leftLabel() }">
+    <label>Allies Fainted</label>
+    <mat-button-toggle-group class="allies-fainted-group" [hideSingleSelectionIndicator]="true" [ngClass]="{ focus: haveFocus() }" data-cy="allies-fainted">
+      @for (value of alliesFainted; track value) {
+        <mat-button-toggle [checked]="value === pokemon().moveSet.activeMove.alliesFainted" (change)="alliesFaintedSelected(value)" [attr.data-cy]="'allies-fainted-' + value">
+          {{ value }}
+        </mat-button-toggle>
+      }
+    </mat-button-toggle-group>
+  </div>
 }
 
 @if (pokemon().activeMoveName === "Stomping Tantrum") {

--- a/src/app/features/pokemon-build/multi-hit-combo-box/multi-hit-combo-box.component.scss
+++ b/src/app/features/pokemon-build/multi-hit-combo-box/multi-hit-combo-box.component.scss
@@ -1,0 +1,44 @@
+@use "variables.scss" as *;
+
+:host {
+  display: block;
+}
+
+:host:has(.allies-fainted) {
+  width: 100% !important;
+}
+
+.allies-fainted {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2em;
+  width: 100%;
+}
+
+.allies-fainted-row {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5em;
+
+  label {
+    white-space: nowrap;
+  }
+}
+
+.allies-fainted-group {
+  --mat-button-toggle-height: 28px;
+  --mat-button-toggle-label-text-weight: 400;
+  --mat-button-toggle-label-text-size: #{$font-size};
+
+  flex: 1;
+  flex-wrap: wrap;
+  width: 100%;
+
+  mat-button-toggle {
+    flex: 1;
+  }
+}
+
+.focus {
+  box-shadow: inset 0 0 0 1.8px white;
+}

--- a/src/app/features/pokemon-build/multi-hit-combo-box/multi-hit-combo-box.component.ts
+++ b/src/app/features/pokemon-build/multi-hit-combo-box/multi-hit-combo-box.component.ts
@@ -1,12 +1,14 @@
+import { NgClass } from "@angular/common"
 import { Component, computed, inject, input, output } from "@angular/core"
 import { FormsModule } from "@angular/forms"
+import { MatButtonToggle, MatButtonToggleGroup } from "@angular/material/button-toggle"
 import { MatCheckbox, MatCheckboxChange } from "@angular/material/checkbox"
 import { InputAutocompleteComponent } from "@basic/input-autocomplete/input-autocomplete.component"
 import { CalculatorStore } from "@data/store/calculator-store"
 
 @Component({
   selector: "app-multi-hit-combo-box",
-  imports: [FormsModule, MatCheckbox, InputAutocompleteComponent],
+  imports: [FormsModule, NgClass, MatCheckbox, MatButtonToggle, MatButtonToggleGroup, InputAutocompleteComponent],
   templateUrl: "./multi-hit-combo-box.component.html",
   styleUrl: "./multi-hit-combo-box.component.scss"
 })
@@ -22,11 +24,16 @@ export class MultiHitComboBoxComponent {
   pokemon = computed(() => this.store.findPokemonById(this.pokemonId()))
   multiHitLabel = computed(() => (this.pokemon().activeMoveName !== "Rage Fist" ? "Hits" : "Hits Taken"))
 
-  alliesFainted = computed(() => (this.pokemon().ability.name === "Supreme Overlord" ? ["0", "1", "2", "3", "4", "5"] : ["0", "1", "2", "3", "4", "5", "6", "7"]))
+  alliesFainted = ["0", "1", "2", "3"]
 
   alliesFaintedChanged(event: string) {
     const activeMovePosition = this.pokemon().moveSet.activeMovePosition
     this.store.alliesFainted(this.pokemonId(), event, activeMovePosition)
+  }
+
+  alliesFaintedSelected(value: string) {
+    this.alliesFaintedChanged(value)
+    this.selected.emit()
   }
 
   hitsChanged(event: string) {


### PR DESCRIPTION
Closes #17

### What

Replaces the **Allies Fainted** dropdown with a segmented row of **clickable number buttons** for **Last Respects** and **Supreme Overlord**, so setting the value is a single click and
the whole range is visible at a glance.

### Why

Allies Fainted only holds a small fixed range (**0–7** / **0–5**). A dropdown needed two interactions and hid the options; buttons make it one tap.

added `data-cy="allies-fainted-<n>"` per button.
- **`multi-hit-combo-box.component.ts`** — added `MatButtonToggle` / `MatButtonToggleGroup` imports and `alliesFaintedSelected(value)`, reusing the existing `alliesFaintedChanged` and
emitting the existing `selected` output (keeps focus handling).
- **`multi-hit-combo-box.component.scss`** — layout for label + toggle group; buttons `flex: 1`; full-width scoped via `:host:has(.allies-fainted)` so the Hits dropdown's mobile `45%`
width stays untouched.
- **`styles.scss`** — reduced `.mat-button-toggle-label-content` padding for these toggles (scoped under `app-multi-hit-combo-box`).

### Screenshot

PC:

<img width="787" height="339" alt="image" src="https://github.com/user-attachments/assets/8416d520-6b9d-43dd-b568-d9eea2529f6c" />

Mobile:

<img width="360" height="403" alt="image" src="https://github.com/user-attachments/assets/95bc82ec-68fe-4438-a75d-4fe6d6377266" />

### How to test

1. Select a Pokémon with **Last Respects** (e.g. Basculegion) and pick that move — or set the **Supreme Overlord** ability.
2. Allies Fainted shows buttons **0–7** (or **0–5** for Supreme Overlord); click a number and confirm BP / damage updates (e.g. `0 → 50 BP`, `5 → 300 BP`).
3. Narrow the window: the buttons span the full line on a single row.
4. The multi-hit **Hits** selector is unchanged (still a dropdown).

### Out of scope / follow-up

- Cypress `allieFainted` page-object helper needs updating to click `[data-cy="allies-fainted-<n>"]` instead of `mat-option`.