### PR TITLE
feat: Click a Pokémon in the speed list to auto-set Speed EVs (outspeed by 1)

### DIFF
--- a/src/app/pages/speed-calc/speed-calculator-mobile/speed-calculator-mobile.component.html
+++ b/src/app/pages/speed-calc/speed-calculator-mobile/speed-calculator-mobile.component.html
@@ -70,7 +70,7 @@
 
       <div [hidden]="overlay.isAnyOpen()">
         @if (!pokemon().isDefault) {
-          <app-speed-scale class="speed-scale" [pokemonId]="speedCalcPokemonId()" [pokemonEachSide]="12" (pokemonSelected)="selectedPokemon.set($event)" />
+          <app-speed-scale class="speed-scale" [pokemonId]="speedCalcPokemonId()" [pokemonEachSide]="12" (pokemonSelected)="onSpeedTierSelected($event)" />
         } @else {
           <div class="empty-insights">Select a Pokémon</div>
         }

--- a/src/app/pages/speed-calc/speed-calculator-mobile/speed-calculator-mobile.component.ts
+++ b/src/app/pages/speed-calc/speed-calculator-mobile/speed-calculator-mobile.component.ts
@@ -15,11 +15,13 @@ import { TeamTabsMobileComponent } from "@features/team/team-tabs-mobile/team-ta
 import { TeamsMobileComponent } from "@features/team/teams-mobile/teams-mobile.component"
 import { AutomaticFieldService } from "@lib/automatic-field-service"
 import { Pokemon } from "@lib/model/pokemon"
+import { SnackbarService } from "@lib/snackbar.service"
 import { getFinalSpeed } from "@lib/smogon/stat-calculator/spe/modified-spe"
 import { Regulation } from "@lib/types"
 import { BackNavigationService } from "@lib/back-navigation.service"
 import { OpponentOptionsComponent } from "@pages/speed-calc/opponent-options/opponent-options.component"
 import { SpeedInsightsComponent } from "@pages/speed-calc/speed-insights/speed-insights.component"
+import { SpeedMatchService } from "@pages/speed-calc/speed-match.service"
 import { SpeedScaleComponent } from "@pages/speed-calc/speed-scale/speed-scale.component"
 import { ImportPokemonButtonComponent } from "@features/buttons/import-pokemon-button/import-pokemon-button.component"
 import { ExportPokemonButtonComponent } from "@features/buttons/export-pokemon-button/export-pokemon-button.component"
@@ -62,6 +64,8 @@ export class SpeedCalculatorMobileComponent implements OnDestroy {
   overlay = inject(MobileTableOverlayService)
   private automaticFieldService = inject(AutomaticFieldService)
   private backNavigation = inject(BackNavigationService)
+  private speedMatch = inject(SpeedMatchService)
+  private snackbar = inject(SnackbarService)
 
   activeBottomTab = signal<"main" | "speed-insights" | "settings" | "teams">("main")
   private scrollPositions = new Map<string, number>()
@@ -318,6 +322,16 @@ export class SpeedCalculatorMobileComponent implements OnDestroy {
         this.scrollContainer.nativeElement.scrollTo({ top: targetScroll, behavior: "instant" })
       }
     }, 0)
+  }
+
+  onSpeedTierSelected(pokemon: Pokemon) {
+    this.selectedPokemon.set(pokemon)
+
+    const outcome = this.speedMatch.matchSpeed(this.speedCalcPokemonId(), pokemon, this.fieldStore.field())
+
+    if (outcome.message) {
+      this.snackbar.open(outcome.message)
+    }
   }
 
   onTeamSelected(pokemonId: string) {

--- a/src/app/pages/speed-calc/speed-calculator/speed-calculator.component.html
+++ b/src/app/pages/speed-calc/speed-calculator/speed-calculator.component.html
@@ -5,7 +5,7 @@
 
 @if (!isPokemonDefault()) {
   <div class="speed-list">
-    <app-speed-list (pokemonSelected)="selectedPokemon.set($event)" />
+    <app-speed-list (pokemonSelected)="onPokemonSelected($event)" />
     <app-speed-insights [pokemon]="selectedPokemon()" />
   </div>
 }

--- a/src/app/pages/speed-calc/speed-calculator/speed-calculator.component.ts
+++ b/src/app/pages/speed-calc/speed-calculator/speed-calculator.component.ts
@@ -7,8 +7,10 @@ import { TeamComponent } from "@features/team/team/team.component"
 import { TeamsDesktopComponent } from "@features/team/teams-desktop/teams-desktop.component"
 import { AutomaticFieldService } from "@lib/automatic-field-service"
 import { Pokemon } from "@lib/model/pokemon"
+import { SnackbarService } from "@lib/snackbar.service"
 import { SpeedInsightsComponent } from "@pages/speed-calc/speed-insights/speed-insights.component"
 import { SpeedListComponent } from "@pages/speed-calc/speed-list/speed-list.component"
+import { SpeedMatchService } from "@pages/speed-calc/speed-match.service"
 
 @Component({
   selector: "app-speed-calculator",
@@ -20,6 +22,9 @@ import { SpeedListComponent } from "@pages/speed-calc/speed-list/speed-list.comp
 export class SpeedCalculatorComponent {
   store = inject(CalculatorStore)
   private automaticFieldService = inject(AutomaticFieldService)
+  private fieldStore = inject(FieldStore)
+  private speedMatch = inject(SpeedMatchService)
+  private snackbar = inject(SnackbarService)
 
   selectedPokemon = signal<Pokemon>(this.store.team().activePokemon())
 
@@ -53,5 +58,15 @@ export class SpeedCalculatorComponent {
         this.selectedPokemon.set(this.store.team().activePokemon())
       }
     })
+  }
+
+  onPokemonSelected(pokemon: Pokemon) {
+    this.selectedPokemon.set(pokemon)
+
+    const outcome = this.speedMatch.matchSpeed(this.pokemonId(), pokemon, this.fieldStore.field())
+
+    if (outcome.message) {
+      this.snackbar.open(outcome.message)
+    }
   }
 }

--- a/src/app/pages/speed-calc/speed-match.service.ts
+++ b/src/app/pages/speed-calc/speed-match.service.ts
@@ -1,0 +1,79 @@
+import { inject, Injectable } from "@angular/core"
+import { CalculatorStore } from "@data/store/calculator-store"
+import { Field } from "@lib/model/field"
+import { Pokemon } from "@lib/model/pokemon"
+import { getFinalSpeed } from "@lib/smogon/stat-calculator/spe/modified-spe"
+import { SpeedEvOptimizer } from "@lib/speed-calculator/speed-ev-optimizer"
+import { evToSp, spToEv, totalSpsFromEvs } from "@lib/utils/ev-sp-converter"
+
+const MAX_TOTAL_EVS = 508
+const MAX_TOTAL_SPS = 66
+
+export type SpeedMatchOutcome = {
+  status: "applied" | "unreachable" | "insufficient" | "ignored"
+  message: string
+}
+
+type BudgetPlan = {
+  fits: boolean
+  needed: number
+  free: number
+  unit: string
+  speedEv: number
+}
+
+@Injectable({
+  providedIn: "root"
+})
+export class SpeedMatchService {
+  private store = inject(CalculatorStore)
+  private optimizer = inject(SpeedEvOptimizer)
+
+  matchSpeed(activePokemonId: string, target: Pokemon, field: Field): SpeedMatchOutcome {
+    const active = this.store.findPokemonById(activePokemonId)
+
+    if (target.id === active.id) {
+      return { status: "ignored", message: "" }
+    }
+
+    const targetSpeed = getFinalSpeed(target, field, false)
+    const result = this.optimizer.outspeed(active, targetSpeed, field, true)
+
+    if (!result.outspeeds || result.speedEv == null) {
+      return { status: "unreachable", message: `${active.name} can't outspeed ${target.name} with a legal spread` }
+    }
+
+    const plan = this.budgetPlan(active, result.speedEv)
+
+    if (!plan.fits) {
+      return { status: "insufficient", message: `Not enough ${plan.unit} to outspeed ${target.name}: needs ${plan.needed}, ${plan.free} free` }
+    }
+
+    this.store.evs(active.id, { ...active.evs, spe: plan.speedEv })
+
+    if (result.natureChanged) {
+      this.store.nature(active.id, result.nature)
+    }
+
+    return { status: "applied", message: `${active.name} set to outspeed ${target.name} (${plan.needed} ${plan.unit}${result.natureChanged ? `, ${result.nature}` : ""})` }
+  }
+
+  private budgetPlan(pokemon: Pokemon, neededEv: number): BudgetPlan {
+    if (this.store.isChampions()) {
+      const neededSps = this.ceilSps(neededEv)
+      const freeSps = MAX_TOTAL_SPS - (totalSpsFromEvs(pokemon.evs) - evToSp(pokemon.evs.spe))
+
+      return { fits: neededSps <= freeSps, needed: neededSps, free: freeSps, unit: "SP", speedEv: spToEv(neededSps) }
+    }
+
+    const freeEvs = MAX_TOTAL_EVS - (pokemon.totalEvs - pokemon.evs.spe)
+
+    return { fits: neededEv <= freeEvs, needed: neededEv, free: freeEvs, unit: "EVs", speedEv: neededEv }
+  }
+
+  private ceilSps(ev: number): number {
+    const sps = evToSp(ev)
+
+    return spToEv(sps) >= ev ? sps : sps + 1
+  }
+}

--- a/src/lib/speed-calculator/speed-ev-optimizer.spec.ts
+++ b/src/lib/speed-calculator/speed-ev-optimizer.spec.ts
@@ -1,0 +1,98 @@
+import { provideZonelessChangeDetection } from "@angular/core"
+import { TestBed } from "@angular/core/testing"
+import { Field } from "@lib/model/field"
+import { Pokemon } from "@lib/model/pokemon"
+import { getFinalSpeed } from "@lib/smogon/stat-calculator/spe/modified-spe"
+import { SpeedEvOptimizer } from "@lib/speed-calculator/speed-ev-optimizer"
+
+describe("SpeedEvOptimizer", () => {
+  let optimizer: SpeedEvOptimizer
+  let field: Field
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [SpeedEvOptimizer, provideZonelessChangeDetection()]
+    })
+
+    optimizer = TestBed.inject(SpeedEvOptimizer)
+    field = new Field()
+  })
+
+  const speedAt = (pokemon: Pokemon, nature: string, ev: number): number => getFinalSpeed(pokemon.clone({ nature, evs: { spe: ev } }), field, true)
+
+  describe("outspeed", () => {
+    it("should outspeed a slower opponent without any speed investment", () => {
+      const pokemon = new Pokemon("Garchomp", { nature: "Jolly" })
+      const opponentSpeed = speedAt(pokemon, "Jolly", 0) - 5
+
+      const result = optimizer.outspeed(pokemon, opponentSpeed, field)
+
+      expect(result.outspeeds).toBe(true)
+      expect(result.speedEv).toBe(0)
+      expect(result.natureChanged).toBe(false)
+    })
+
+    it("should return the minimum speed EV needed to outspeed by one point", () => {
+      const pokemon = new Pokemon("Garchomp", { nature: "Jolly" })
+      const opponentSpeed = speedAt(pokemon, "Jolly", 100)
+
+      const result = optimizer.outspeed(pokemon, opponentSpeed, field)
+
+      expect(result.outspeeds).toBe(true)
+      expect(result.finalSpeed!).toBeGreaterThan(opponentSpeed)
+      expect(result.speedEv === 0 || speedAt(pokemon, "Jolly", result.speedEv! - 4) <= opponentSpeed).toBe(true)
+    })
+
+    it("should be infeasible when even max investment cannot outspeed", () => {
+      const pokemon = new Pokemon("Garchomp", { nature: "Jolly" })
+      const opponentSpeed = speedAt(pokemon, "Jolly", 252) + 20
+
+      const result = optimizer.outspeed(pokemon, opponentSpeed, field)
+
+      expect(result.outspeeds).toBe(false)
+      expect(result.speedEv).toBeNull()
+    })
+
+    it("should switch to a positive speed nature when a neutral spread is not enough", () => {
+      const pokemon = new Pokemon("Garchomp", { nature: "Adamant" })
+      const opponentSpeed = speedAt(pokemon, "Adamant", 252)
+
+      const result = optimizer.outspeed(pokemon, opponentSpeed, field)
+
+      expect(result.outspeeds).toBe(true)
+      expect(result.natureChanged).toBe(true)
+      expect(result.nature).toBe("Jolly")
+    })
+
+    it("should keep the current nature when it already suffices", () => {
+      const pokemon = new Pokemon("Garchomp", { nature: "Jolly" })
+      const opponentSpeed = speedAt(pokemon, "Jolly", 0)
+
+      const result = optimizer.outspeed(pokemon, opponentSpeed, field)
+
+      expect(result.outspeeds).toBe(true)
+      expect(result.natureChanged).toBe(false)
+      expect(result.nature).toBe("Jolly")
+    })
+  })
+
+  describe("minSpeedEv", () => {
+    it("should return zero when the base speed already meets the target", () => {
+      const pokemon = new Pokemon("Garchomp", { nature: "Jolly" })
+      const targetSpeed = speedAt(pokemon, "Jolly", 0)
+
+      const ev = optimizer.minSpeedEv(pokemon, targetSpeed, field, "Jolly")
+
+      expect(ev).toBe(0)
+    })
+
+    it("should return null when the target is unreachable", () => {
+      const pokemon = new Pokemon("Garchomp", { nature: "Jolly" })
+      const targetSpeed = speedAt(pokemon, "Jolly", 252) + 20
+
+      const ev = optimizer.minSpeedEv(pokemon, targetSpeed, field, "Jolly")
+
+      expect(ev).toBeNull()
+    })
+  })
+})

--- a/src/lib/speed-calculator/speed-ev-optimizer.ts
+++ b/src/lib/speed-calculator/speed-ev-optimizer.ts
@@ -1,0 +1,70 @@
+import { Injectable } from "@angular/core"
+import { Field } from "@lib/model/field"
+import { Pokemon } from "@lib/model/pokemon"
+import { getFinalSpeed } from "@lib/smogon/stat-calculator/spe/modified-spe"
+
+export type SpeedTuneResult = {
+  speedEv: number | null
+  nature: string
+  natureChanged: boolean
+  finalSpeed: number | null
+  outspeeds: boolean
+}
+
+const MAX_SPEED_EVS = 252
+const EV_STEP = 4
+
+@Injectable({
+  providedIn: "root"
+})
+export class SpeedEvOptimizer {
+  outspeed(pokemon: Pokemon, opponentSpeed: number, field: Field, isAttacker = true): SpeedTuneResult {
+    const targetSpeed = opponentSpeed + 1
+
+    const evWithCurrentNature = this.minSpeedEv(pokemon, targetSpeed, field, pokemon.nature, isAttacker)
+
+    if (evWithCurrentNature != null) {
+      return this.buildResult(pokemon, targetSpeed, field, pokemon.nature, evWithCurrentNature, false, isAttacker)
+    }
+
+    const positiveNature = this.positiveSpeedNature(pokemon)
+
+    if (positiveNature != pokemon.nature) {
+      const evWithPositiveNature = this.minSpeedEv(pokemon, targetSpeed, field, positiveNature, isAttacker)
+
+      if (evWithPositiveNature != null) {
+        return this.buildResult(pokemon, targetSpeed, field, positiveNature, evWithPositiveNature, true, isAttacker)
+      }
+    }
+
+    return { speedEv: null, nature: pokemon.nature, natureChanged: false, finalSpeed: null, outspeeds: false }
+  }
+
+  minSpeedEv(pokemon: Pokemon, targetSpeed: number, field: Field, nature: string, isAttacker = true): number | null {
+    for (let ev = 0; ev <= MAX_SPEED_EVS; ev += EV_STEP) {
+      const speed = this.speedWith(pokemon, field, nature, ev, isAttacker)
+
+      if (speed >= targetSpeed) {
+        return ev
+      }
+    }
+
+    return null
+  }
+
+  private buildResult(pokemon: Pokemon, targetSpeed: number, field: Field, nature: string, speedEv: number, natureChanged: boolean, isAttacker: boolean): SpeedTuneResult {
+    const finalSpeed = this.speedWith(pokemon, field, nature, speedEv, isAttacker)
+
+    return { speedEv, nature, natureChanged, finalSpeed, outspeeds: finalSpeed >= targetSpeed }
+  }
+
+  private speedWith(pokemon: Pokemon, field: Field, nature: string, ev: number, isAttacker: boolean): number {
+    const clonedPokemon = pokemon.clone({ nature, evs: { spe: ev } })
+
+    return getFinalSpeed(clonedPokemon, field, isAttacker)
+  }
+
+  private positiveSpeedNature(pokemon: Pokemon): string {
+    return pokemon.higherStat === "spa" ? "Timid" : "Jolly"
+  }
+}


### PR DESCRIPTION
Closes #16

## What

Adds a "click to outspeed" capability to the existing speed list: clicking a Pokémon in the speed list sets the active Pokémon's Speed EVs to outspeed it by one point, reusing the page field so Tailwind / Trick Room / Icy Wind / paralysis / Choice Scarf are all honored.

This follows the direction we agreed on in #16 (your alternative #5): no new panel — it reuses the existing speed list and its visual feedback, which animates to the new position. Works on both desktop and mobile.

## How

- **`SpeedEvOptimizer`** (lib) — pure speed math: given a target final speed + field, returns the minimum Speed EV (switching to a positive speed nature only when a neutral spread can't reach it), or reports infeasible. Reuses `getFinalSpeed`, so field effects are honored. Unit-tested.
- **`SpeedMatchService`** (speed-calc) — orchestrates the optimizer, spends only **free** budget (never steals EVs from other stats), and gives snackbar feedback:
  - already faster -> no change;
  - unreachable even at max investment -> "can't outspeed";
  - not enough free budget -> tells you what's missing, in the active mode's unit (**SP** for Champions, **EVs** for SV).
- Wired onto the existing `pokemonSelected` output from the speed list (`speed-box` / `speed-scale` untouched), on both the desktop and mobile speed calculators. On mobile it targets the speed-calc scratch Pokémon, consistent with how the mobile EV sliders edit it.

## Notes / follow-ups

- The "outspeed by 1" margin is fixed for now; easy to make configurable later.

## Tests

- `SpeedEvOptimizer` unit tests (7) pass.
- Manually validated on the speed-calc page (desktop and mobile, SV and Champions), including the budget/feedback messages.