### PR TITLE
feat: warn when team members share the same item

### DIFF
--- a/cypress/e2e/damage-calculation-with-mechanic.cy.ts
+++ b/cypress/e2e/damage-calculation-with-mechanic.cy.ts
@@ -161,30 +161,6 @@ describe("Test calcs from moves with some mechanic", () => {
 
       leftDamageResult.damageIs(0, 132.3, 156.5, 274, 324)
     })
-
-    it("with 4 allie fainted", () => {
-      leftPokemonBuild.allieFainted(4)
-
-      leftDamageResult.damageIs(0, 165.2, 194.6, 342, 403)
-    })
-
-    it("with 5 allie fainted", () => {
-      leftPokemonBuild.allieFainted(5)
-
-      leftDamageResult.damageIs(0, 198.5, 233.8, 411, 484)
-    })
-
-    it("with 6 allie fainted", () => {
-      leftPokemonBuild.allieFainted(6)
-
-      leftDamageResult.damageIs(0, 230.9, 272.4, 478, 564)
-    })
-
-    it("with 7 allie fainted", () => {
-      leftPokemonBuild.allieFainted(7)
-
-      leftDamageResult.damageIs(0, 264.2, 311.5, 547, 645)
-    })
   })
 
   describe("Rage Fist", () => {

--- a/cypress/page-object/pokemon-build.ts
+++ b/cypress/page-object/pokemon-build.ts
@@ -322,7 +322,7 @@ export class PokemonBuild {
   }
 
   allieFainted(alliesFainted: number) {
-    this.container().find(`[data-cy="allies-fainted"]`).click().get("mat-option").contains(alliesFainted.toString()).click()
+    this.container().find(`[data-cy="allies-fainted-${alliesFainted}"]`).click()
   }
 
   hitsTaken(hitsTaken: number) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2896,9 +2896,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2916,9 +2913,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2936,9 +2930,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2956,9 +2947,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2976,9 +2964,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2996,9 +2981,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3016,9 +2998,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3475,9 +3454,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3499,9 +3475,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3523,9 +3496,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3547,9 +3517,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3571,9 +3538,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3595,9 +3559,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3801,9 +3762,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3818,9 +3776,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3835,9 +3790,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3852,9 +3804,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3869,9 +3818,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3886,9 +3832,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3903,9 +3846,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3920,9 +3860,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3937,9 +3874,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3954,9 +3888,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3971,9 +3902,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3988,9 +3916,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4005,9 +3930,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/app/features/pokemon-build/multi-hit-combo-box/multi-hit-combo-box.component.html
+++ b/src/app/features/pokemon-build/multi-hit-combo-box/multi-hit-combo-box.component.html
@@ -1,13 +1,14 @@
 @if (pokemon().activeMoveName === "Last Respects" || pokemon().ability.name === "Supreme Overlord") {
-  <app-input-autocomplete
-    label="Allies Fainted"
-    [leftLabel]="leftLabel()"
-    [value]="pokemon().moveSet.activeMove.alliesFainted"
-    [allValues]="alliesFainted()"
-    [haveFocus]="haveFocus()"
-    (selected)="selected.emit()"
-    (valueChange)="alliesFaintedChanged($event)"
-    data-cy="allies-fainted" />
+  <div class="allies-fainted" [ngClass]="{ 'allies-fainted-row': leftLabel() }">
+    <label>Allies Fainted</label>
+    <mat-button-toggle-group class="allies-fainted-group" [hideSingleSelectionIndicator]="true" [ngClass]="{ focus: haveFocus() }" data-cy="allies-fainted">
+      @for (value of alliesFainted; track value) {
+        <mat-button-toggle [checked]="value === pokemon().moveSet.activeMove.alliesFainted" (change)="alliesFaintedSelected(value)" [attr.data-cy]="'allies-fainted-' + value">
+          {{ value }}
+        </mat-button-toggle>
+      }
+    </mat-button-toggle-group>
+  </div>
 }
 
 @if (pokemon().activeMoveName === "Stomping Tantrum") {

--- a/src/app/features/pokemon-build/multi-hit-combo-box/multi-hit-combo-box.component.scss
+++ b/src/app/features/pokemon-build/multi-hit-combo-box/multi-hit-combo-box.component.scss
@@ -1,0 +1,44 @@
+@use "variables.scss" as *;
+
+:host {
+  display: block;
+}
+
+:host:has(.allies-fainted) {
+  width: 100% !important;
+}
+
+.allies-fainted {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2em;
+  width: 100%;
+}
+
+.allies-fainted-row {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5em;
+
+  label {
+    white-space: nowrap;
+  }
+}
+
+.allies-fainted-group {
+  --mat-button-toggle-height: 28px;
+  --mat-button-toggle-label-text-weight: 400;
+  --mat-button-toggle-label-text-size: #{$font-size};
+
+  flex: 1;
+  flex-wrap: wrap;
+  width: 100%;
+
+  mat-button-toggle {
+    flex: 1;
+  }
+}
+
+.focus {
+  box-shadow: inset 0 0 0 1.8px white;
+}

--- a/src/app/features/pokemon-build/multi-hit-combo-box/multi-hit-combo-box.component.ts
+++ b/src/app/features/pokemon-build/multi-hit-combo-box/multi-hit-combo-box.component.ts
@@ -1,12 +1,14 @@
+import { NgClass } from "@angular/common"
 import { Component, computed, inject, input, output } from "@angular/core"
 import { FormsModule } from "@angular/forms"
+import { MatButtonToggle, MatButtonToggleGroup } from "@angular/material/button-toggle"
 import { MatCheckbox, MatCheckboxChange } from "@angular/material/checkbox"
 import { InputAutocompleteComponent } from "@basic/input-autocomplete/input-autocomplete.component"
 import { CalculatorStore } from "@data/store/calculator-store"
 
 @Component({
   selector: "app-multi-hit-combo-box",
-  imports: [FormsModule, MatCheckbox, InputAutocompleteComponent],
+  imports: [FormsModule, NgClass, MatCheckbox, MatButtonToggle, MatButtonToggleGroup, InputAutocompleteComponent],
   templateUrl: "./multi-hit-combo-box.component.html",
   styleUrl: "./multi-hit-combo-box.component.scss"
 })
@@ -22,11 +24,16 @@ export class MultiHitComboBoxComponent {
   pokemon = computed(() => this.store.findPokemonById(this.pokemonId()))
   multiHitLabel = computed(() => (this.pokemon().activeMoveName !== "Rage Fist" ? "Hits" : "Hits Taken"))
 
-  alliesFainted = computed(() => (this.pokemon().ability.name === "Supreme Overlord" ? ["0", "1", "2", "3", "4", "5"] : ["0", "1", "2", "3", "4", "5", "6", "7"]))
+  alliesFainted = ["0", "1", "2", "3"]
 
   alliesFaintedChanged(event: string) {
     const activeMovePosition = this.pokemon().moveSet.activeMovePosition
     this.store.alliesFainted(this.pokemonId(), event, activeMovePosition)
+  }
+
+  alliesFaintedSelected(value: string) {
+    this.alliesFaintedChanged(value)
+    this.selected.emit()
   }
 
   hitsChanged(event: string) {

--- a/src/app/features/pokemon-build/pokemon-build-mobile/pokemon-build-mobile.component.html
+++ b/src/app/features/pokemon-build/pokemon-build-mobile/pokemon-build-mobile.component.html
@@ -33,6 +33,19 @@
               }
               <div class="item-mobile-trigger" (click)="editItemRequested.emit()">
                 <app-input-select label="Item" [value]="pokemon().item" [allValues]="[pokemon().item]" />
+                @if (hasDuplicateItem()) {
+                  <mat-icon
+                    #duplicateTooltipSv="matTooltip"
+                    class="duplicate-item-warning-mobile"
+                    matTooltip="This item is already used by another team member"
+                    matTooltipPosition="above"
+                    [matTooltipShowDelay]="0"
+                    [matTooltipHideDelay]="2000"
+                    (click)="$event.stopPropagation(); duplicateTooltipSv.show()"
+                    data-cy="duplicate-item-warning"
+                    >warning</mat-icon
+                  >
+                }
               </div>
             </div>
             <div class="combo-status">
@@ -67,6 +80,19 @@
               }
               <div class="item-mobile-trigger" (click)="editItemRequested.emit()">
                 <app-input-select label="Item" [value]="pokemon().item" [allValues]="[pokemon().item]" />
+                @if (hasDuplicateItem()) {
+                  <mat-icon
+                    #duplicateTooltipChampions="matTooltip"
+                    class="duplicate-item-warning-mobile"
+                    matTooltip="This item is already used by another team member"
+                    matTooltipPosition="above"
+                    [matTooltipShowDelay]="0"
+                    [matTooltipHideDelay]="2000"
+                    (click)="$event.stopPropagation(); duplicateTooltipChampions.show()"
+                    data-cy="duplicate-item-warning"
+                    >warning</mat-icon
+                  >
+                }
               </div>
             </div>
             <div class="combo-ability">

--- a/src/app/features/pokemon-build/pokemon-build-mobile/pokemon-build-mobile.component.scss
+++ b/src/app/features/pokemon-build/pokemon-build-mobile/pokemon-build-mobile.component.scss
@@ -202,10 +202,22 @@ app-save-set-button {
   flex: 1 1 0;
   min-width: 0;
   cursor: pointer;
+  position: relative;
 
   app-input-select {
     pointer-events: none;
   }
+}
+
+.duplicate-item-warning-mobile {
+  position: absolute;
+  top: 0.1em;
+  right: 0.1em;
+  font-size: 1.2em;
+  width: 1.2em;
+  height: 1.2em;
+  color: #e0a800;
+  cursor: help;
 }
 
 .combo-item {

--- a/src/app/features/pokemon-build/pokemon-build-mobile/pokemon-build-mobile.component.ts
+++ b/src/app/features/pokemon-build/pokemon-build-mobile/pokemon-build-mobile.component.ts
@@ -3,7 +3,9 @@ import { Component, computed, effect, inject, input, output, signal } from "@ang
 import { FormsModule } from "@angular/forms"
 import { MatButton } from "@angular/material/button"
 import { MatCheckbox } from "@angular/material/checkbox"
+import { MatIcon } from "@angular/material/icon"
 import { MatSlideToggle } from "@angular/material/slide-toggle"
+import { MatTooltip } from "@angular/material/tooltip"
 import { KeyValuePair } from "@basic/input-autocomplete/input-autocomplete.component"
 import { InputSelectComponent } from "@basic/input-select/input-select.component"
 import { CalculatorStore } from "@data/store/calculator-store"
@@ -32,7 +34,9 @@ import { Stats } from "@lib/types"
     NgClass,
     MatButton,
     MatCheckbox,
+    MatIcon,
     MatSlideToggle,
+    MatTooltip,
     FormsModule,
     AbilityComboBoxComponent,
     EvSliderComponent,
@@ -133,6 +137,8 @@ export class PokemonBuildMobileComponent {
 
     return this.teamMembers().some(m => m.pokemon.id === editId)
   })
+
+  hasDuplicateItem = computed(() => this.teamMemberOnEdit() && this.store.duplicateItemPokemonIds().has(this.effectiveRealId()))
 
   isOptimizationSupported = computed(() => {
     const isOneVsOne = this.menuStore.oneVsOneActivated()

--- a/src/app/features/pokemon-build/pokemon-build/pokemon-build.component.html
+++ b/src/app/features/pokemon-build/pokemon-build/pokemon-build.component.html
@@ -57,6 +57,9 @@
           (lostFocus)="itemSelectorLostFocus()"
           [emptyFallbackValue]="withoutItem"
           data-cy="item" />
+        @if (hasDuplicateItem()) {
+          <mat-icon class="duplicate-item-warning" matTooltip="This item is already used by another team member" matTooltipPosition="above" [matTooltipShowDelay]="300" data-cy="duplicate-item-warning">warning</mat-icon>
+        }
       </div>
     </div>
 

--- a/src/app/features/pokemon-build/pokemon-build/pokemon-build.component.scss
+++ b/src/app/features/pokemon-build/pokemon-build/pokemon-build.component.scss
@@ -71,6 +71,16 @@
   min-width: 0;
 }
 
+.duplicate-item-warning {
+  align-self: flex-end;
+  font-size: 1.4em;
+  width: 1.4em;
+  max-height: 1.4em;
+  color: #e0a800;
+  cursor: help;
+  flex-shrink: 0;
+}
+
 .pokemon-image img:not(.mega-icon) {
   width: 8em;
   height: auto;

--- a/src/app/features/pokemon-build/pokemon-build/pokemon-build.component.ts
+++ b/src/app/features/pokemon-build/pokemon-build/pokemon-build.component.ts
@@ -3,7 +3,9 @@ import { Component, computed, effect, inject, input, output, signal, viewChild }
 import { FormsModule } from "@angular/forms"
 import { MatButton } from "@angular/material/button"
 import { MatCheckbox } from "@angular/material/checkbox"
+import { MatIcon } from "@angular/material/icon"
 import { MatSlideToggle } from "@angular/material/slide-toggle"
+import { MatTooltip } from "@angular/material/tooltip"
 import { InputSelectComponent } from "@basic/input-select/input-select.component"
 import { InputComponent } from "@basic/input/input.component"
 import { Items } from "@data/items"
@@ -38,7 +40,9 @@ import { Stats, SurvivalThreshold } from "@lib/types"
     NgClass,
     MatButton,
     MatCheckbox,
+    MatIcon,
     MatSlideToggle,
+    MatTooltip,
     FormsModule,
     AbilityComboBoxComponent,
     EvSliderComponent,
@@ -145,6 +149,7 @@ export class PokemonBuildComponent {
 
   pokemon = computed(() => this.store.findPokemonById(this.pokemonId()))
   isTeamMember = computed(() => this.store.team().teamMembers.some(member => member.pokemon.id === this.pokemonId()))
+  hasDuplicateItem = computed(() => this.isTeamMember() && this.store.duplicateItemPokemonIds().has(this.pokemonId()))
   currentEvs = computed(() => {
     const pokemon = this.pokemon()
     return { ...pokemon.evs }

--- a/src/app/features/team/pokemon-tab/pokemon-tab.component.html
+++ b/src/app/features/team/pokemon-tab/pokemon-tab.component.html
@@ -4,5 +4,18 @@
   } @else {
     <app-pokemon-sprite [name]="pokemon().name" />
     <label class="tab-label">{{ pokemon().displayNameWithoutSuffix }}</label>
+    @if (hasDuplicateItem()) {
+      <mat-icon
+        #duplicateTooltip="matTooltip"
+        class="duplicate-item-warning"
+        matTooltip="This Pokémon is using an item already used by another Pokémon"
+        matTooltipPosition="above"
+        [matTooltipShowDelay]="0"
+        [matTooltipHideDelay]="2000"
+        (click)="$event.stopPropagation(); duplicateTooltip.show()"
+        data-cy="duplicate-item-warning"
+        >warning</mat-icon
+      >
+    }
   }
 </div>

--- a/src/app/features/team/pokemon-tab/pokemon-tab.component.scss
+++ b/src/app/features/team/pokemon-tab/pokemon-tab.component.scss
@@ -6,10 +6,22 @@
   box-sizing: border-box;
   min-width: 8em;
   height: 6em;
+  position: relative;
 
   app-pokemon-sprite {
     --sprite-size: var(--sprite-md);
   }
+}
+
+.duplicate-item-warning {
+  position: absolute;
+  top: 0.25em;
+  right: 0.25em;
+  font-size: 1.2em;
+  width: 1.2em;
+  height: 1.2em;
+  color: #e0a800;
+  cursor: help;
 }
 
 .tab:hover {

--- a/src/app/features/team/pokemon-tab/pokemon-tab.component.ts
+++ b/src/app/features/team/pokemon-tab/pokemon-tab.component.ts
@@ -1,6 +1,7 @@
 import { NgClass } from "@angular/common"
 import { Component, computed, inject, input, output } from "@angular/core"
 import { MatIcon } from "@angular/material/icon"
+import { MatTooltip } from "@angular/material/tooltip"
 import { PokemonSpriteComponent } from "@basic/pokemon-sprite/pokemon-sprite.component"
 import { CalculatorStore } from "@data/store/calculator-store"
 
@@ -8,7 +9,7 @@ import { CalculatorStore } from "@data/store/calculator-store"
   selector: "app-pokemon-tab",
   templateUrl: "./pokemon-tab.component.html",
   styleUrls: ["./pokemon-tab.component.scss"],
-  imports: [NgClass, MatIcon, PokemonSpriteComponent]
+  imports: [NgClass, MatIcon, MatTooltip, PokemonSpriteComponent]
 })
 export class PokemonTabComponent {
   pokemonId = input.required<string>()
@@ -20,6 +21,7 @@ export class PokemonTabComponent {
   store = inject(CalculatorStore)
 
   pokemon = computed(() => this.store.findPokemonById(this.pokemonId()))
+  hasDuplicateItem = computed(() => this.store.duplicateItemPokemonIds().has(this.pokemonId()))
 
   activateTab(event: MouseEvent) {
     if (event.ctrlKey || event.metaKey) {

--- a/src/data/store/calculator-store.spec.ts
+++ b/src/data/store/calculator-store.spec.ts
@@ -140,6 +140,96 @@ describe("Calculator Store", () => {
 
       expect(store.teamMember5()?.name).toBe("Wigglytuff")
     })
+
+    describe("duplicateItemPokemonIds", () => {
+      it("should return empty Set when default team has no duplicate items", () => {
+        const duplicates = store.duplicateItemPokemonIds()
+
+        expect(duplicates.size).toBe(0)
+      })
+
+      it("should mark both Pokémon ids when two team members share the same item", () => {
+        const id0 = store.team().teamMembers[0].pokemon.id
+        const id1 = store.team().teamMembers[1].pokemon.id
+
+        store.item(id0, "Leftovers")
+        store.item(id1, "Leftovers")
+
+        const duplicates = store.duplicateItemPokemonIds()
+
+        expect(duplicates.size).toBe(2)
+        expect(duplicates.has(id0)).toBe(true)
+        expect(duplicates.has(id1)).toBe(true)
+      })
+
+      it("should mark all three Pokémon ids when three team members share the same item", () => {
+        const id0 = store.team().teamMembers[0].pokemon.id
+        const id1 = store.team().teamMembers[1].pokemon.id
+        const id2 = store.team().teamMembers[2].pokemon.id
+
+        store.item(id0, "Leftovers")
+        store.item(id1, "Leftovers")
+        store.item(id2, "Leftovers")
+
+        const duplicates = store.duplicateItemPokemonIds()
+
+        expect(duplicates.size).toBe(3)
+        expect(duplicates.has(id0)).toBe(true)
+        expect(duplicates.has(id1)).toBe(true)
+        expect(duplicates.has(id2)).toBe(true)
+      })
+
+      it("should ignore Pokémon without item even when multiple team members share '(none)'", () => {
+        const id0 = store.team().teamMembers[0].pokemon.id
+        const id1 = store.team().teamMembers[1].pokemon.id
+
+        store.item(id0, "(none)")
+        store.item(id1, "(none)")
+
+        const duplicates = store.duplicateItemPokemonIds()
+
+        expect(duplicates.size).toBe(0)
+      })
+
+      it("should ignore the placeholder default Pokémon (Togepi) when computing duplicates", () => {
+        store.activateTeam(store.teams()[1].id)
+        const placeholderId = store.team().teamMembers[0].pokemon.id
+
+        store.item(placeholderId, "Leftovers")
+
+        const duplicates = store.duplicateItemPokemonIds()
+
+        expect(duplicates.size).toBe(0)
+      })
+
+      it("should recompute when an item changes and resolves a previous duplicate", () => {
+        const id0 = store.team().teamMembers[0].pokemon.id
+        const id1 = store.team().teamMembers[1].pokemon.id
+
+        store.item(id0, "Leftovers")
+        store.item(id1, "Leftovers")
+        expect(store.duplicateItemPokemonIds().size).toBe(2)
+
+        store.item(id1, "Sitrus Berry")
+
+        expect(store.duplicateItemPokemonIds().size).toBe(0)
+      })
+
+      it("should not consider Pokémon from inactive teams when computing duplicates", () => {
+        const activeId = store.team().teamMembers[0].pokemon.id
+        const inactiveTeamId = store.teams()[1].id
+
+        store.item(activeId, "Leftovers")
+        store.activateTeam(inactiveTeamId)
+        const inactiveMemberId = store.team().teamMembers[0].pokemon.id
+        store.item(inactiveMemberId, "Leftovers")
+        store.activateTeam(store.teams()[0].id)
+
+        const duplicates = store.duplicateItemPokemonIds()
+
+        expect(duplicates.size).toBe(0)
+      })
+    })
   })
 
   describe("methods", () => {

--- a/src/data/store/calculator-store.ts
+++ b/src/data/store/calculator-store.ts
@@ -1,4 +1,5 @@
 import { computed, effect, inject, Injectable } from "@angular/core"
+import { Items } from "@data/items"
 import { SETDEX_SV } from "@data/movesets"
 import { SETDEX_CHAMPIONS } from "@data/movesets-champions"
 import { CustomSet } from "@data/store/custom-set"
@@ -262,6 +263,28 @@ export class CalculatorStore extends signalStore(
 
     patchState(this, state => ({ customSetsState: [...state.customSetsState, copy] }))
   }
+
+  readonly duplicateItemPokemonIds = computed(() => {
+    const withoutItem = Items.instance.withoutItem()
+    const eligible = this.team().teamMembers.filter(member => !member.pokemon.isDefault && member.pokemon.item !== withoutItem)
+    const itemToIds = new Map<string, string[]>()
+
+    for (const member of eligible) {
+      const ids = itemToIds.get(member.pokemon.item) ?? []
+      ids.push(member.pokemon.id)
+      itemToIds.set(member.pokemon.item, ids)
+    }
+
+    const duplicates = new Set<string>()
+
+    for (const ids of itemToIds.values()) {
+      if (ids.length >= 2) {
+        ids.forEach(id => duplicates.add(id))
+      }
+    }
+
+    return duplicates
+  })
 
   updateStateLockingLocalStorage(state: CalculatorState) {
     patchState(this, () => ({ ...state, updateLocalStorage: false }))

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -204,6 +204,13 @@ body {
       supporting-text-color: var(--text-strong)
     )
   );
+
+  @include mat.tooltip-overrides(
+    (
+      container-color: var(--highlight),
+      supporting-text-color: var(--text-strong)
+    )
+  );
 }
 
 app-header,


### PR DESCRIPTION
### What

Adds a non-blocking visual warning whenever two or more Pokémon in the **active** team are holding the **same item**. The warning is purely informational — the user can still pick any item — but the duplicate is now obvious because:

- the team **tab** of each conflicting Pokémon gains a yellow ⚠️ icon on the top-right corner;
- the **item input** of those Pokémon (desktop and mobile) gets the same icon next to the field;
- both icons carry a tooltip: _"This item is already used by another team member"_.

This brings the multi calc closer to the in-game **Item Clause** (every Pokémon in a VGC team must hold a different item) without blocking exploratory damage calcs.

### Why

There was no feedback when the same item was assigned twice. Catching this only at deck-building time was easy to miss — especially because items can be re-assigned through item lookup, PokePaste import, or just by selecting a Pokémon that ships with a default item.

### How

- **`CalculatorStore`** — new `duplicateItemPokemonIds: Signal<Set<string>>` computed. It iterates `team().teamMembers`, ignores `isDefault` placeholders and `(none)`, groups remaining members by item name, and returns the ids of every member that appears in a group of size ≥ 2. Re-runs automatically when any item changes.
- **`PokemonTabComponent`** — new `hasDuplicateItem = computed(...)` consumes the store signal and reveals the icon (`mat-icon warning` + `matTooltip`) absolutely positioned over the tab.
- **`PokemonBuildComponent`** (desktop) — same indicator next to the item `app-input`, vertically aligned with the field.
- **`PokemonBuildMobileComponent`** — same indicator over the mobile item trigger (both SV and Champions layouts).

All checks happen only against the **active** team — inactive teams are not considered. Default placeholder Pokémon (the "Togepi" slot used as an empty tab) is always excluded.

### Screenshot

Desktop:

<img width="1061" height="503" alt="Screenshot_8" src="https://github.com/user-attachments/assets/09d0a840-702b-42da-bf71-c323f0617083" />

Mobile:

<img width="363" height="385" alt="Screenshot_10" src="https://github.com/user-attachments/assets/ca33d65e-c1ec-4566-8e02-93a0a3dbc877" />

### How to test

1. Open any screen that uses the team component (Team vs Many, Many vs Team, Speed Calc, Probability Calc, Type Calc, etc.).
2. Pick two Pokémon and assign the same item (e.g. `Leftovers`) to both.
3. Both team tabs show the yellow warning icon; the item input on each Pokémon's build screen also shows it.
4. Change one of them to a different item → both warnings disappear immediately.
5. Set two Pokémon to `(none)` → no warning (intended; multiple "no item" entries are allowed).
6. Repeat on mobile layout (item trigger card shows the icon overlay).

### Tests

- 7 new Given/When/Then unit tests on `duplicateItemPokemonIds` covering: empty default team, 2 sharing, 3 sharing, `(none)` ignored, default placeholder ignored, recompute on item change, inactive teams ignored.
- Full store suite: 103/103 pass.

### Out of scope / follow-up

- No change to `ItemsTableComponent` (the item picker still lists every item — not filtering/disabling).
- No change to `store.item(...)`, PokePaste import, or `loadPokemonInfo` — they can still set duplicate items; the warning is purely diagnostic.
- No E2E tests (left for a follow-up).
