### PR TITLE
fix: list only the added opponent Pokémon in the Opponent Defenders filter

### DIFF
--- a/src/app/pages/multi-calc/target-pokemon/target-pokemon.component.html
+++ b/src/app/pages/multi-calc/target-pokemon/target-pokemon.component.html
@@ -6,7 +6,7 @@
         label="Pokémon"
         leftLabel="true"
         [enableClear]="cardsFilter() !== ''"
-        [allValues]="pokemonNamesByReg()"
+        [allValues]="targetPokemonNames()"
         [value]="cardsFilter()"
         (valueChange)="updateCardsFilter($event)"
         (cleared)="clearCardsFilter()" />

--- a/src/app/pages/multi-calc/target-pokemon/target-pokemon.component.ts
+++ b/src/app/pages/multi-calc/target-pokemon/target-pokemon.component.ts
@@ -92,11 +92,11 @@ export class TargetPokemonComponent {
     return this.store.game() === "champions" ? SETDEX_CHAMPIONS : SETDEX_SV
   }
 
-  readonly pokemonNamesByReg = computed(() =>
-    pokemonByRegulation(this.regulation() as Regulation, undefined, this.store.game() === "champions" ? SETDEX_CHAMPIONS : SETDEX_SV, true, this.store.isChampions())
-      .map(s => s.name)
-      .sort()
-  )
+  readonly targetPokemonNames = computed(() => {
+    const names = this.damageResults().flatMap(result => (this.isAttacker() ? [result.attacker.name, result.secondAttacker?.name] : [result.defender.name]))
+
+    return [...new Set(names.filter((name): name is string => !!name))].sort()
+  })
 
   readonly regulationsList = computed(() => (this.store.game() === "champions" ? ["MA"] : ["I"]))
 

--- a/src/app/pages/multi-calc/target-pokemon/target-pokemon.component.ts
+++ b/src/app/pages/multi-calc/target-pokemon/target-pokemon.component.ts
@@ -93,7 +93,7 @@ export class TargetPokemonComponent {
   }
 
   readonly pokemonNamesByReg = computed(() =>
-    pokemonByRegulation(this.regulation() as Regulation, undefined, this.store.game() === "champions" ? SETDEX_CHAMPIONS : SETDEX_SV, false, this.store.isChampions())
+    pokemonByRegulation(this.regulation() as Regulation, undefined, this.store.game() === "champions" ? SETDEX_CHAMPIONS : SETDEX_SV, true, this.store.isChampions())
       .map(s => s.name)
       .sort()
   )


### PR DESCRIPTION
### What

The **Opponent Defenders** name filter on the **Team vs Many** screen now lists **only the Pokémon that are actually in the list**, built dynamically from the current cards. The options update automatically as Pokémon are added or removed.

Previously the autocomplete was built from a curated meta list (`topUsageByRegulation`), which had two problems:

- it was missing newly available Pokémon (e.g. **Staraptor**), so they could be added as targets but not found through the filter;
- it showed Pokémon that were not even in the list, which is misleading — the filter looked like the place where you add Pokémon.

### Why

A name filter should reflect what is on screen. Tying it to a static regulation list made it both incomplete (missing new Pokémon) and confusing (suggesting Pokémon that are not in the list). Deriving the options from the current results is simpler, always correct, and clearer for the user.

### How

- **`TargetPokemonComponent`** — replaced the `pokemonNamesByReg` computed (which called `pokemonByRegulation(...)`) with `targetPokemonNames`, derived from `damageResults()`. It collects the defender names (or attacker / second-attacker names when used for Opponent Attackers), de-duplicates them, and sorts alphabetically.
- The template binds the autocomplete `[allValues]` to `targetPokemonNames()`.

The **Add Meta** behavior is untouched (it still uses `pokemonByRegulation(...)`), and the mobile view shares the same component, so it is fixed automatically.

### How to test

1. Open **Team vs Many** and add a few Pokémon to **Opponent Defenders**.
2. Open the **Pokémon** filter: only the Pokémon currently in the list are suggested.
3. Type a name that is not in the list (e.g. `Staraptor`) → no options.
4. Type the name of one that is in the list → it is suggested and the cards filter accordingly.
5. Add/remove a Pokémon → the filter options update immediately.